### PR TITLE
Refactor OrValidator.validate

### DIFF
--- a/strictyaml/validators.py
+++ b/strictyaml/validators.py
@@ -34,28 +34,10 @@ class OrValidator(Validator):
             location = YAMLLocation()
             document = copy.deepcopy(document)
 
-        error1 = None
-        error2 = None
-
         try:
-            validation_a = self._validator_a(document, location=location)
-        except YAMLValidationError as err:
-            error1 = err
-
-        try:
-            validation_b = self._validator_b(document, location=location)
-        except YAMLValidationError as err:
-            error2 = err
-
-        if error1 is None:
-            return validation_a
-        if error2 is None:
-            return validation_b
-
-        if error2 is not None:
-            raise error2
-        if error1 is not None:
-            raise error1
+            return self._validator_a(document, location=location)
+        except YAMLValidationError:
+            return self._validator_b(document, location=location)
 
 
 def strip_accoutrements(document):


### PR DESCRIPTION
If `_validator_a` succeeds, we don't need to try `_validator_b` any more, since the result would be unused anyway, and if `_validator_b` fails as well, we always report `_validator_b`s error, so no need to keep the exception from `_validator_a` around.