### PR TITLE
pykwalify and fixed dependency versions

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -668,10 +668,6 @@ Why not use pykwalify to validate YAML instead?
 
 See the question above for the correct times to use kwalify to validate your code and crucially, when not to.
 
-Apart from the kinds of YAML structures which pykwalify is simply *unable* to validate, it also
-`fixes versions in setup.py <https://github.com/Grokzen/pykwalify/issues/55>`_
-which will break your code when upgrading.
-
 
 Why is StrictYAML built upon ruamel.yaml?
 -----------------------------------------


### PR DESCRIPTION
This statement is not true as of commit 8c3327ebbd6d76cd07a48f5ae9c62cee58694090 which closed Grokzen/pykwalify#55. The fix was released with pykwalify version 1.5.2.