### PR TITLE
DOCS : Fix miscopied entry in example pyyaml output

### DIFF
--- a/FAQ.rst
+++ b/FAQ.rst
@@ -30,7 +30,7 @@ What features does StrictYAML remove?
 | `Flow style`_            | .. code-block:: yaml  | .. code-block:: python                | .. code-block:: python             |
 |                          |                       |                                       |                                    |
 |                          |      x: 1             |      load(yaml) == \                  |     raises FlowStyleDisallowed     |
-|                          |      b: {c: 3, d: 4}  |      {'x': {'a': 1}, 'y': {'a': 1}}   |                                    |
+|                          |      b: {c: 3, d: 4}  |      {'x': 1, 'b': {'c': 3, 'd': 4}}  |                                    |
 +--------------------------+-----------------------+---------------------------------------+------------------------------------+
 | `Duplicate keys`_        | .. code-block:: yaml  | .. code-block:: python                | .. code-block:: python             |
 |                          |                       |                                       |                                    |


### PR DESCRIPTION
Simple doc fix.

(Sorry I didn't see (or look for) the contribution guidelines. Feel free to prepend `DOCS : ` to the commit message.)