### PR TITLE
MISC: Fix ResourceWarning: unclosed file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ import os
 def read(*parts):
     # intentionally *not* adding an encoding option to open
     # see here: https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
-    return codecs.open(os.path.join(os.path.abspath(os.path.dirname(__file__)), *parts), 'r').read()
+    with codecs.open(os.path.join(os.path.abspath(os.path.dirname(__file__)), *parts)) as f:
+        return f.read()
 
 
 setup(name="strictyaml",


### PR DESCRIPTION
Hello,

This is a little fix for a `ResourceWarning`.
Example:
```shell
$ export PYTHONWARNINGS=once
$ python3 setup.py install
setup.py:14: ResourceWarning: unclosed file <_io.TextIOWrapper name=.../strictyaml/VERSION' mode='r' encoding='UTF-8'>
  return codecs.open(os.path.join(os.path.abspath(os.path.dirname(__file__)), *parts), 'r').read()
setup.py:14: ResourceWarning: unclosed file <_io.TextIOWrapper name='.../strictyaml/README.md' mode='r' encoding='UTF-8'>
  return codecs.open(os.path.join(os.path.abspath(os.path.dirname(__file__)), *parts), 'r').read()
running install
running bdist_egg
...
```