### PR TITLE
Revert "Revert "BUG: issue #72.  Now __setitem__ uses schema.""

### DIFF
--- a/hitch/story/update-with-schema.story
+++ b/hitch/story/update-with-schema.story
@@ -1,0 +1,31 @@
+Updating document with a schema:
+  docs: compound/update
+  based on: strictyaml
+  description: |
+    When StrictYAML loads a document with a schema, it checks that future
+    updates to that document follow the original schema.
+  given:
+    setup: |
+      import strictyaml as s
+      from ensure import Ensure
+  variations:
+    GitHub \#72:
+      steps:
+      - Run: |-
+          doc = s.load('a: 9', s.Map({
+            'a': s.Str(),
+            s.Optional('b'): s.Int(),
+          }))
+          doc['b'] = 9
+          assert doc['b'] == 9
+
+    Can assign from string:
+      steps:
+      - Run: |-
+          doc = s.load('a: 9', s.Map({
+            'a': s.Str(),
+            s.Optional('b'): s.Int(),
+          }))
+          doc['b'] = '9'
+          assert doc['b'] == 9
+

--- a/strictyaml/representation.py
+++ b/strictyaml/representation.py
@@ -192,11 +192,17 @@ class YAML(object):
 
     def __setitem__(self, index, value):
         strictindex = self._strictindex(index)
-        try:
-            value_validator = self._value[strictindex].validator
-        except KeyError:
-            # TODO: What if value isn't a YAML object?
-            value_validator = value.validator
+        if self.is_mapping():
+            value_validator = (
+                    self._selected_validator._validator_dict[strictindex]
+                    if self._selected_validator is not None
+                    else self._validator._validator_dict[strictindex])
+        else:
+            try:
+                value_validator = self._value[strictindex].validator
+            except KeyError:
+                # TODO: What if value isn't a YAML object?
+                value_validator = value.validator
 
         new_value = (
             value_validator(value._chunk)


### PR DESCRIPTION
This is a replacement for https://github.com/crdoconnor/strictyaml/pull/75

I merged and then reverted the original PR. This unmerged branch contains a revert of that revert.

This code unfortunately causes story "Boolean (Bool)/Update boolean values with string and bool type" to fail (and possibly some others). @wwoods can you run the test and see what happened?

Once all the tests pass - i.e. "hk regression" has no failures, I'll be happy to merge a new pull request.