### PR TITLE
BUG: issue #72.  Now __setitem__ uses schema.

### DIFF
--- a/hitch/story/update-with-schema.story
+++ b/hitch/story/update-with-schema.story
@@ -1,0 +1,93 @@
+Updating document with a schema:
+  docs: compound/update
+  based on: strictyaml
+  description: |
+    When StrictYAML loads a document with a schema, it checks that future
+    updates to that document follow the original schema.
+  given:
+    setup: |
+      import strictyaml as s
+      from ensure import Ensure
+  variations:
+    GitHub \#72:
+      steps:
+      - Run: |-
+          doc = s.load('a: 9', s.Map({
+            'a': s.Str(),
+            s.Optional('b'): s.Int(),
+          }))
+          doc['b'] = 9
+          assert doc['b'] == 9
+
+    Works on empty mapping:
+      steps:
+      - Run: |-
+          doc = s.load('', s.EmptyDict() | s.Map({
+            'a': s.Int(),
+          }))
+          doc['a'] = 9
+          assert doc['a'] == 9, doc.as_yaml()
+
+    Works on complex types:
+      steps:
+      - Run: |-
+          doc = s.load('a: 8', s.Map({'a': s.Int() | s.Float()}))
+          assert type(doc['a'].data) == int, repr(doc.data)
+          doc['a'] = '5.'
+          assert type(doc['a'].data) == float, repr(doc.data)
+          assert doc['a'] == 5.
+
+    Will not work on empty sequence:
+      steps:
+      - Run:
+          code: |
+            doc = s.load('', s.EmptyList() | s.Seq(s.Int()))
+            doc[0] = 9
+          raises:
+            type: strictyaml.exceptions.YAMLSerializationError
+            message: |-
+                cannot extend list via __setitem__.  Instead, replace whole list on parent node.
+
+    Works on map with setting, updating, and then setting multiple keys (regression):
+      steps:
+      - Run:
+          code: |
+            doc = s.load('', s.EmptyDict() | s.MapPattern(
+              s.Str(),
+              s.EmptyDict() | s.Map({
+                s.Optional('b'): s.Seq(s.Int()),
+              })
+            ))
+            doc['a'] = {}
+            doc['a']['b'] = ['9']
+            assert doc.data == {'a': {'b': [9]}}, doc.data
+            assert doc.as_yaml() == 'a:\n  b:\n  - 9\n', doc.as_yaml()
+            # Second assignment doesn't occur...
+            doc['a']['b'] = ['9', '10']
+            assert doc.data == {'a': {'b': [9, 10]}}, doc.data
+            assert doc.as_yaml() == 'a:\n  b:\n  - 9\n  - 10\n', doc.as_yaml()
+            # If and only if another node is overwritten.  This was a bug due
+            # to mismatched _ruamelparsed objects.
+            doc['b'] = {'b': ['11']}
+            assert doc['a']['b'].data == [9, 10], doc.data
+            assert doc['b']['b'].data == [11], doc.data
+            assert doc.as_yaml() == 'a:\n  b:\n  - 9\n  - 10\nb:\n  b:\n  - 11\n', doc.as_yaml()
+
+    For empty sequence, must instead assign whole sequence as key:
+      steps:
+      - Run: |-
+          doc = s.load('a:', s.Map({'a': s.EmptyList() | s.Seq(s.Int())}))
+          doc['a'] = [1, 2, 3]
+          assert doc['a'].data == [1, 2, 3], repr(doc.data)
+
+
+    Can assign from string:
+      steps:
+      - Run: |-
+          doc = s.load('a: 9', s.Map({
+            'a': s.Str(),
+            s.Optional('b'): s.Int(),
+          }))
+          doc['b'] = '9'
+          assert doc['b'] == 9
+

--- a/strictyaml/any_validator.py
+++ b/strictyaml/any_validator.py
@@ -2,7 +2,7 @@ from ruamel.yaml.comments import CommentedSeq, CommentedMap
 from strictyaml.compound import FixedSeq, Map
 from strictyaml.validators import Validator
 from strictyaml.exceptions import YAMLSerializationError
-from strictyaml.scalar import Str
+from strictyaml.scalar import Bool, EmptyDict, EmptyList, Float, Int, Str
 
 
 def schema_from_document(document):
@@ -16,19 +16,29 @@ def schema_from_document(document):
         return Str()
 
 
-def schema_from_data(data):
+def schema_from_data(data, allow_empty):
     if isinstance(data, dict):
         if len(data) == 0:
+            if allow_empty:
+                return EmptyDict()
             raise YAMLSerializationError(
                 "Empty dicts are not serializable to StrictYAML unless schema is used."
             )
-        return Map({key: schema_from_data(value) for key, value in data.items()})
+        return Map({key: schema_from_data(value, allow_empty) for key, value in data.items()})
     elif isinstance(data, list):
         if len(data) == 0:
+            if allow_empty:
+                return EmptyList()
             raise YAMLSerializationError(
                 "Empty lists are not serializable to StrictYAML unless schema is used."
             )
-        return FixedSeq([schema_from_data(item) for item in data])
+        return FixedSeq([schema_from_data(item, allow_empty) for item in data])
+    elif isinstance(data, bool):
+        return Bool()
+    elif isinstance(data, int):
+        return Int()
+    elif isinstance(data, float):
+        return Float()
     else:
         return Str()
 
@@ -41,8 +51,13 @@ class Any(Validator):
     def validate(self, chunk):
         return schema_from_document(chunk.contents)(chunk)
 
-    def to_yaml(self, data):
-        return schema_from_data(data).to_yaml(data)
+    def to_yaml(self, data, allow_empty=False):
+        """
+        Args:
+            allow_empty (bool): True to allow EmptyDict and EmptyList in the
+                    schema generated from the data.
+        """
+        return schema_from_data(data, allow_empty=allow_empty).to_yaml(data)
 
     @property
     def key_validator(self):

--- a/strictyaml/scalar.py
+++ b/strictyaml/scalar.py
@@ -8,6 +8,7 @@ import dateutil.parser
 import decimal
 import sys
 import re
+from ruamel.yaml.scalarstring import PreservedScalarString
 
 
 if sys.version_info[0] == 3:
@@ -148,7 +149,10 @@ class Str(ScalarValidator):
     def to_yaml(self, data):
         if not utils.is_string(data):
             raise YAMLSerializationError("'{}' is not a string".format(data))
-        return str(data)
+        s = str(data)
+        if u"\n" in s:
+            s = PreservedScalarString(s)
+        return s
 
 
 class Int(ScalarValidator):

--- a/strictyaml/utils.py
+++ b/strictyaml/utils.py
@@ -77,10 +77,13 @@ def is_decimal(value):
     >>> is_decimal("3.5")
     True
 
+    >>> is_decimal("4.")
+    True
+
     >>> is_decimal("blah")
     False
     """
-    return compile(r"^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$").match(value) is not None
+    return compile(r"^[-+]?[0-9]*(\.[0-9]*)?([eE][-+]?[0-9]+)?$").match(value) is not None
 
 
 def comma_separated_positions(text):

--- a/strictyaml/yamllocation.py
+++ b/strictyaml/yamllocation.py
@@ -149,6 +149,12 @@ class YAMLChunk(object):
             label=self.label,
             key_association=copy(self._key_association),
         )
+        if self.is_scalar():
+            # Necessary for e.g. EmptyDict, which reports as a scalar.
+            forked_chunk.pointer.set(forked_chunk, '_ruamelparsed',
+                                     CommentedMap())
+            forked_chunk.pointer.set(forked_chunk, '_strictparsed',
+                                     CommentedMap(), strictdoc=True)
         forked_chunk.contents[self.ruamelindex(strictindex)] = new_value.as_marked_up()
         forked_chunk.strictparsed()[strictindex] = deepcopy(new_value.as_marked_up())
         return forked_chunk


### PR DESCRIPTION
Before this commit, schemas could be violated when assigning to
Map/Sequence members.  Now, modifications to the data must fit the
data's schema.

Furthermore, if the node on which __setitem__ is called has a compound
schema, the selected validator within the compound schema may change
correctly.

------

This fixes #72, #76, and supersedes #75.  @crdoconnor I'm pretty happy with this in that it works on all tests without any changes, and supports the new test suite.  There are two strange aspects which you may want to weigh in on:

1. The _strictparsed option, which to me had no clear semantics, is overwritten with `self`.  This works to preserve the hierarchy and required methods, but I'm not sure if this would break anything else.  At any rate, again, all the tests pass, and it seems to behave sanely.

2. I make no claims about optimality in terms of speed of this approach.  Frankly, you'd probably need to rewrite a few of the internals if that were the chief concern of this library.  That said, I did try to prevent multiple validations a few places, but there are likely more ways to invoke validations of already-validated content, which is harmless but could eventually lead to a performance problem.

Please let me know if you do/do not merge this; I'm going ahead with my professional project assuming this (or a slight variant) will be accepted and rolled into a version that I'll be able to have clients pull down in the near future.