### PR TITLE
DOCS: Fix syntax in docs/why-not/hocon.md

### DIFF
--- a/docs/why-not/hocon.md
+++ b/docs/why-not/hocon.md
@@ -8,6 +8,6 @@ Along with JSON's [syntax typing](../../why/syntax-typing-bad) - a downside of m
 
 - It does not fail loudly on duplicate keys.
 - It has a confusing rules for deciding on concatenations and substitutions.
--* It has a mechanism for substitutions similar to YAML's node/anchor feature - which, unless used extremely sparingly, can create confusing markup that, ironically, is *not* human optimized.
+- It has a mechanism for substitutions similar to [YAML's node anchor feature](../why/node-anchors-and-references-removed.md) - which, unless used extremely sparingly, can create confusing markup that, ironically, is *not* human optimized.
 
 In addition, its attempt at using "less pedantic" syntax creates a system of rules which makes the behavior of the parser much less obvious and edge cases more frequent.


### PR DESCRIPTION
The `-*` syntax seems to have been inadvertently introduced in 36dbac1, considering that the previous version used `*` for all three list items.

Also link to the doc explaining the node anchor/references feature of YAML.