### PR TITLE
BUGFIX: Fix for #116 - handle Enum or integers errors

### DIFF
--- a/hitch/story/enum-with-item-validation.story
+++ b/hitch/story/enum-with-item-validation.story
@@ -20,3 +20,48 @@ Enum with item validation:
       - Run:
           code: |
             Ensure(load(yaml_snippet, schema)).equals({"a": 1})
+
+    Invalid because D is not an integer:
+      given:
+        yaml_snippet: 'a: D'
+      steps:
+      - Run:
+          code: load(yaml_snippet, schema)
+          raises:
+            type: strictyaml.exceptions.YAMLValidationError
+            message: |-
+              when expecting an integer
+              found arbitrary text
+                in "<unicode string>", line 1, column 1:
+                  a: D
+                   ^ (line: 1)
+
+    Invalid because 4 is not in enum:
+      given:
+        yaml_snippet: 'a: 4'
+      steps:
+      - Run:
+          code: load(yaml_snippet, schema)
+          raises:
+            type: strictyaml.exceptions.YAMLValidationError
+            message: |-
+              when expecting one of: 1, 2, 3
+              found arbitrary text
+                in "<unicode string>", line 1, column 1:
+                  a: 4
+                   ^ (line: 1)
+
+    Invalid because blank string is not in enum:
+      given:
+        yaml_snippet: 'a:'
+      steps:
+      - Run:
+          code: load(yaml_snippet, schema)
+          raises:
+            type: strictyaml.exceptions.YAMLValidationError
+            message: |-
+              when expecting one of: 1, 2, 3
+              found a blank string
+                in "<unicode string>", line 1, column 1:
+                  a: ''
+                   ^ (line: 1)

--- a/strictyaml/scalar.py
+++ b/strictyaml/scalar.py
@@ -50,7 +50,7 @@ class Enum(ScalarValidator):
         val._validator = self
         if val.scalar not in self._restricted_to:
             chunk.expecting_but_found(
-                "when expecting one of: {0}".format(", ".join(self._restricted_to))
+                "when expecting one of: {0}".format(", ".join(map(str,self._restricted_to)))
             )
         else:
             return val
@@ -59,7 +59,7 @@ class Enum(ScalarValidator):
         if data not in self._restricted_to:
             raise YAMLSerializationError(
                 "Got '{0}' when  expecting one of: {1}".format(
-                    data, ", ".join(self._restricted_to)
+                    data, ", ".join(map(str,self._restricted_to))
                 )
             )
         return self._item_validator.to_yaml(data)


### PR DESCRIPTION
Enum doesn't return proper error message when using Enum with Integer, like the example in #116.

Fixing the issue by converting value to str before doing the join.

I've also updated the enum-with-item-validation.story to verify this bug. I didn't found the quick method to run the story validation but I don't see why it wouldn't work.