### PR TITLE
BUGFIX: Support None as Optional default (#62) , add default to Optional.__repr__

### DIFF
--- a/strictyaml/compound.py
+++ b/strictyaml/compound.py
@@ -12,7 +12,9 @@ if sys.version_info[0] == 3:
 
 
 class Optional(object):
-    def __init__(self, key, default=None):
+    NO_DEFAULT = object()
+
+    def __init__(self, key, default=NO_DEFAULT):
         self.key = key
         self.default = default
 
@@ -110,7 +112,7 @@ class Map(MapValidator):
 
         for key_val, value_val in validator.items():
             if isinstance(key_val, Optional):
-                if key_val.default is not None:
+                if key_val.default is not Optional.NO_DEFAULT:
                     try:
                         value_val.to_yaml(key_val.default)
                     except YAMLSerializationError as error:
@@ -123,7 +125,7 @@ class Map(MapValidator):
         self._defaults = {
             key.key: key.default
             for key in validator.keys()
-            if isinstance(key, Optional) and key.default is not None
+            if isinstance(key, Optional) and key.default is not Optional.NO_DEFAULT
         }
 
     @property

--- a/strictyaml/compound.py
+++ b/strictyaml/compound.py
@@ -19,8 +19,10 @@ class Optional(object):
         self.default = default
 
     def __repr__(self):
-        # TODO: Add default
-        return u'Optional("{0}")'.format(self.key)
+        if self.default is Optional.NO_DEFAULT:
+            return u'Optional("{0}")'.format(self.key)
+        else:
+            return u'Optional("{0}", default={1})'.format(self.key, repr(self.default))
 
 
 class MapPattern(MapValidator):


### PR DESCRIPTION
#62 mentions that `None` is not supported as default value in Optional.
Fix this by adding a unique object and checking for identity when determining if the default value exists or not.

Also add the default value to `__repr__`

Btw: is there a timeline for when default values in Optionals will become stable? They haven't changed in the last two years.