### PR TITLE
FEATURE: Support underscores in int and decimal

### DIFF
--- a/hitch/story/float.story
+++ b/hitch/story/float.story
@@ -82,6 +82,16 @@ Floating point numbers (Float):
               Ensure(isinf(load(yaml_snippet, schema)["a"].data)).is_true()
               Ensure(isinf(load(yaml_snippet, schema)["b"].data)).is_true()
 
+    Has underscores:
+      given:
+        yaml_snippet: |
+          a: 10_000_000.5
+          b: 10_0_0.2_5
+      steps:
+        - Run:
+            code: |
+              Ensure(load(yaml_snippet, schema).data).equals({"a": 10000000.5, "b": 1000.25})
+
     Cannot cast to bool:
       steps:
       - Run:

--- a/hitch/story/scalar-integer.story
+++ b/hitch/story/scalar-integer.story
@@ -26,6 +26,16 @@ Integers (Int):
       - Run: |
           Ensure(parsed).equals({"a": 1, "b": 5})
 
+    Has underscores:
+      given:
+        yaml_snippet: |
+          a: 10_000_000
+          b: 10_0_0
+      steps:
+        - Run:
+            code: |
+              Ensure(load(yaml_snippet, schema).data).equals({"a": 10_000_000, "b": 10_0_0})
+
     Cast with str:
       steps:
       - Run: Ensure(str(parsed["a"])).equals("1")

--- a/strictyaml/scalar.py
+++ b/strictyaml/scalar.py
@@ -164,7 +164,8 @@ class Int(ScalarValidator):
         if not utils.is_integer(val):
             chunk.expecting_but_found("when expecting an integer")
         else:
-            return int(val)
+            # Only Python 3.6+ supports underscores in numeric literals
+            return int(val.replace("_", ""))
 
     def to_yaml(self, data):
         if utils.is_string(data) or isinstance(data, int):
@@ -205,7 +206,8 @@ class Float(ScalarValidator):
             val = val.replace(".", "")
         elif not utils.is_decimal(val):
             chunk.expecting_but_found("when expecting a float")
-        return float(val)
+        # Only Python 3.6+ supports underscores in numeric literals
+        return float(val.replace("_", ""))
 
     def to_yaml(self, data):
         if utils.has_number_type(data):

--- a/strictyaml/utils.py
+++ b/strictyaml/utils.py
@@ -70,10 +70,13 @@ def is_integer(value):
     >>> is_integer("4")
     True
 
+    >>> is_integer("4_000")
+    True
+
     >>> is_integer("3.4")
     False
     """
-    return compile("^[-+]?[0-9]+$").match(value) is not None
+    return compile(r"^[-+]?[0-9_]+$").match(value) is not None
 
 
 def is_decimal(value):
@@ -83,17 +86,24 @@ def is_decimal(value):
     >>> is_decimal("4")
     True
 
+    >>> is_decimal("4_000")
+    True
+
     >>> is_decimal("3.5")
     True
 
     >>> is_decimal("4.")
     True
 
+    >>> is_decimal("4.000_001")
+    True
+
     >>> is_decimal("blah")
     False
     """
     return (
-        compile(r"^[-+]?[0-9]*(\.[0-9]*)?([eE][-+]?[0-9]+)?$").match(value) is not None
+        compile(r"^[-+]?[0-9_]*(\.[0-9_]*)?([eE][-+]?[0-9_]+)?$").match(value)
+        is not None
     )
 
 


### PR DESCRIPTION
The YAML specification states that underscores in numeric literals should be ignored:

* https://yaml.org/type/int.html
* https://yaml.org/type/float.html

It's also fairly standard practice supported in many languages, including Python itself ([PEP-515](https://www.python.org/dev/peps/pep-0515/)). I think it would be a useful addition to strictyaml as I find this feature to be very useful to avoid mistakes when writing large values in configuration files.

Any thoughts?