### PR TITLE
BUGFIX : Require Regex to be a full match

### DIFF
--- a/hitch/story/regexp.story
+++ b/hitch/story/regexp.story
@@ -40,6 +40,23 @@ Validating strings with regexes (Regex):
                   a: '5'
                    ^ (line: 1)
 
+    Non-matching suffix:
+      given:
+        yaml_snippet: |
+          a: 1 Hello
+          b: 5
+      steps:
+      - Run:
+          code: load(yaml_snippet, schema)
+          raises:
+            type: strictyaml.exceptions.YAMLValidationError
+            message: |-
+              when expecting string matching [1-4]
+              found non-matching string
+                in "<unicode string>", line 1, column 1:
+                  a: 1 Hello
+                   ^ (line: 1)
+
     Serialized successfully:
       steps:
       - Run:


### PR DESCRIPTION
Current the Regex type only requires the string to match the start of the string causing arbitrary content to be allowed on the end:
```python
In [1]: import strictyaml
In [2]: schema = strictyaml.Regex("[0-9]")
In [3]: strictyaml.load("1 Hello", schema=schema)
Out[3]: YAML(1 Hello)
```
This looks like an oversight from the fact that `re.match` is used instead of `re.fullmatch`. With this PR the above example fails with:
```python
strictyaml.exceptions.YAMLValidationError: when expecting string matching [0-9]
  in "<unicode string>", line 1, column 1:
    1 Hello
     ^ (line: 1)
found non-matching string
  in "<unicode string>", line 2, column 1:
    ...
    ^ (line: 2)
```

I also modified the class to cache the compiled regex which could have a significant impact when parsing large objects with many different regular expressions. This can happen as internally [Python uses a cache to remember the last N patterns](https://github.com/python/cpython/blob/8d21aa21f2cbc6d50aab3f420bb23be1d081dac4/Lib/re.py#L228-L241) however if this is ever exceeded the performance will suddenly become significantly worse for no obvious reason due to each regular expression having to be actually compiled when being initialised.