### PR TITLE
FEATURE : MapCombined for arbitrary (not pre-specified) optional keys

### DIFF
--- a/hitch/story/map-combined.story
+++ b/hitch/story/map-combined.story
@@ -1,0 +1,28 @@
+Mappings combining defined and undefined keys (MapCombined):
+  based on: strictyaml
+  experimental: yes
+  description: |
+    See https://github.com/crdoconnor/strictyaml/issues/148#issuecomment-861007657
+  given:
+    setup: |
+      from strictyaml import Any, Int, MapCombined, Optional, Str, load
+      from ensure import Ensure
+
+      schema = MapCombined({
+        "required": Str(),
+        Optional("foo"): Int(),
+        Str(): Any(),
+      })
+    yaml_snippet: |
+      required: Hello World
+      foo: 42
+      bar: 42
+  steps:
+  - Run: |
+      Ensure(load(yaml_snippet, schema).data).equals(
+          {
+              "name": "Hello World",
+              "foo": 42,
+              "bar": "42",
+          }
+      )

--- a/hitch/story/map-combined.story
+++ b/hitch/story/map-combined.story
@@ -8,11 +8,14 @@ Mappings combining defined and undefined keys (MapCombined):
       from strictyaml import Any, Int, MapCombined, Optional, Str, load
       from ensure import Ensure
 
-      schema = MapCombined({
-        "required": Str(),
-        Optional("foo"): Int(),
-        Str(): Any(),
-      })
+      schema = MapCombined(
+        {
+          "required": Str(),
+          Optional("foo"): Int(),
+        },
+        Str(),
+        Any(),
+      )
     yaml_snippet: |
       required: Hello World
       foo: 42
@@ -21,7 +24,7 @@ Mappings combining defined and undefined keys (MapCombined):
   - Run: |
       Ensure(load(yaml_snippet, schema).data).equals(
           {
-              "name": "Hello World",
+              "required": "Hello World",
               "foo": 42,
               "bar": "42",
           }

--- a/hitch/story/map-combined.story
+++ b/hitch/story/map-combined.story
@@ -38,7 +38,7 @@ Mappings combining defined and undefined keys (MapCombined):
                   "bar": "42",
               }
           )
-    "Optional is abscent":
+    "Optional is absent":
       given:
         yaml_snippet: |
           required: Hello World
@@ -66,7 +66,7 @@ Mappings combining defined and undefined keys (MapCombined):
                   "baz": "forty two",
               }
           )
-    "Required is abscent":
+    "Required is absent":
       given:
         yaml_snippet: |
           bar: 42

--- a/hitch/story/map-combined.story
+++ b/hitch/story/map-combined.story
@@ -16,16 +16,119 @@ Mappings combining defined and undefined keys (MapCombined):
         Str(),
         Any(),
       )
-    yaml_snippet: |
-      required: Hello World
-      foo: 42
-      bar: 42
-  steps:
-  - Run: |
-      Ensure(load(yaml_snippet, schema).data).equals(
-          {
-              "required": "Hello World",
-              "foo": 42,
-              "bar": "42",
-          }
-      )
+  variations:
+    "Optional is present":
+      given:
+        yaml_snippet: |
+          required: Hello World
+          foo: 42
+          bar: 42
+      steps:
+      - Run: |
+          Ensure(load(yaml_snippet, schema).data).equals(
+              {
+                  "required": "Hello World",
+                  "foo": 42,
+                  "bar": "42",
+              }
+          )
+    "Optional is abscent":
+      given:
+        yaml_snippet: |
+          required: Hello World
+          bar: 42
+      steps:
+      - Run: |
+          Ensure(load(yaml_snippet, schema).data).equals(
+              {
+                  "required": "Hello World",
+                  "bar": "42",
+              }
+          )
+    "Multiple undefined":
+      given:
+        yaml_snippet: |
+          required: Hello World
+          bar: 42
+          baz: forty two
+      steps:
+      - Run: |
+          Ensure(load(yaml_snippet, schema).data).equals(
+              {
+                  "required": "Hello World",
+                  "bar": "42",
+                  "baz": "forty two",
+              }
+          )
+    "Required is abscent":
+      given:
+        yaml_snippet: |
+          bar: 42
+      steps:
+      - Run:
+          code:
+            load(yaml_snippet, schema)
+          raises:
+            type: strictyaml.exceptions.YAMLValidationError
+            message: |-
+              while parsing a mapping
+              required key(s) 'required' not found
+                in "<unicode string>", line 1, column 1:
+                  bar: '42'
+                   ^ (line: 1)
+    "Undefined of invalid type":
+      given:
+        setup: |
+          from strictyaml import Any, Int, MapCombined, Optional, Str, load
+          from ensure import Ensure
+
+          schema = MapCombined(
+            {
+              "required": Str(),
+            },
+            Str(),
+            Int(),
+          )
+        yaml_snippet: |
+          required: Hello World
+          bar: forty two
+      steps:
+      - Run:
+          code:
+            load(yaml_snippet, schema)
+          raises:
+            type: strictyaml.exceptions.YAMLValidationError
+            message: |-
+              when expecting an integer
+              found arbitrary text
+                in "<unicode string>", line 2, column 1:
+                  bar: forty two
+                  ^ (line: 2)
+    "Invalid key type":
+      given:
+        setup: |
+          from strictyaml import Any, Int, MapCombined, Optional, Str, load
+          from ensure import Ensure
+
+          schema = MapCombined(
+            {
+              "1": Str(),
+            },
+            Int(),
+            Str(),
+          )
+        yaml_snippet: |
+          1: Hello World
+          not_an_integer: 42
+      steps:
+      - Run:
+          code:
+            load(yaml_snippet, schema)
+          raises:
+            type: strictyaml.exceptions.YAMLValidationError
+            message: |-
+              when expecting an integer
+              found arbitrary text
+                in "<unicode string>", line 2, column 1:
+                  not_an_integer: '42'
+                  ^ (line: 2)

--- a/hitch/story/map-combined.story
+++ b/hitch/story/map-combined.story
@@ -1,7 +1,13 @@
 Mappings combining defined and undefined keys (MapCombined):
+  docs: compound/map-combined
   based on: strictyaml
   experimental: yes
   description: |
+    When you wish to support arbitrary optional keys in
+    some mappings (i.e. to specify some required keys in
+    the schema, but allow any additional ones on top of
+    that), you use a MapCombined.
+
     See https://github.com/crdoconnor/strictyaml/issues/148#issuecomment-861007657
   given:
     setup: |

--- a/strictyaml/__init__.py
+++ b/strictyaml/__init__.py
@@ -32,6 +32,7 @@ from strictyaml.scalar import EmptyList
 from strictyaml.compound import Optional
 from strictyaml.compound import Map
 from strictyaml.compound import MapPattern
+from strictyaml.compound import MapCombined
 from strictyaml.compound import Seq
 from strictyaml.compound import UniqueSeq
 from strictyaml.compound import FixedSeq

--- a/strictyaml/compound.py
+++ b/strictyaml/compound.py
@@ -232,9 +232,7 @@ class MapCombined(Map):
         return self._validator_dict.get(key, self._value_validator)
 
     def unexpected_key(self, key, yaml_key, value, chunk):
-        key.process(yaml_key)
-        value.process(self._value_validator(value))
-        chunk.add_key_association(key.contents, yaml_key.data)
+        pass
 
 
 class Seq(SeqValidator):

--- a/strictyaml/compound.py
+++ b/strictyaml/compound.py
@@ -219,6 +219,10 @@ class Map(MapValidator):
         )
 
 
+class MapCombined(Map):
+    pass  # TODO
+
+
 class Seq(SeqValidator):
     def __init__(self, validator):
         self._validator = validator


### PR DESCRIPTION
An attempt to solve https://github.com/crdoconnor/strictyaml/issues/148 - mostly inspired by @Dakta's [comment](https://github.com/crdoconnor/strictyaml/issues/148#issuecomment-861007657) on the `logging` module schema, with slightly adjusted usage:

```python
schema = MapCombined(
    {
        "required": Str(),
        Optional("foo"): Int(),
    }
    Str(),  # validator for keys (both defined and undefined)
    Any(),  # validator for values of undefined keys
})
```

Btw, this is my first experience using HitchStory, and I liked it so much!