### PR TITLE
BUGFIX : Revert bugfix for "Don't check indentation consistency when allowing flow."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ### Latest
 
+* BUG: Don't check indentation consistency when allowing flow.
 
-No relevant code changes.
 
 ### 1.6.0
 

--- a/docs/public/changelog.md
+++ b/docs/public/changelog.md
@@ -3,8 +3,8 @@
 
 ### Latest
 
+* BUG: Don't check indentation consistency when allowing flow.
 
-No relevant code changes.
 
 ### 1.6.0
 

--- a/hitch/story/dirty-load.story
+++ b/hitch/story/dirty-load.story
@@ -6,8 +6,6 @@ Dirty load:
     by default, but since there have since been
     [some requests](https://github.com/crdoconnor/strictyaml/issues/38)
     to parse flow style, this now allowed with the "dirty_load" method.
-    If allow_flow_style is True, Map indentation is not checked for
-    consistency, as the indentation level is dependent on the map key length.
   given:
     setup: |
       from strictyaml import Map, Int, MapPattern, Seq, Str, Any, dirty_load
@@ -17,9 +15,9 @@ Dirty load:
     Flow style mapping:
       given:
         yaml_snippet: |
-          foo: { a: 1, b: 2, c: 3 }
+          x: { a: 1, b: 2, c: 3 }
           y: {}
           z: []
       steps:
       - Run: |
-          assert dirty_load(yaml_snippet, schema, allow_flow_style=True) == {"foo": {"a": "1", "b": "2", "c": "3"}, "y": {}, "z": []}
+          assert dirty_load(yaml_snippet, schema, allow_flow_style=True) == {"x": {"a": "1", "b": "2", "c": "3"}, "y": {}, "z": []}

--- a/strictyaml/parser.py
+++ b/strictyaml/parser.py
@@ -110,28 +110,23 @@ class StrictYAMLConstructor(RoundTripConstructor):
         if merge_map:
             maptyp.add_yaml_merge(merge_map)
 
-        # Don't verify Mapping indentation when allowing flow,
-        # as that disallows:
-        #   short_key: { x = 1 }
-        #   very_long_key: { x = 1 }
-        if not self.allow_flow_style:
-            previous_indentation = None
+        previous_indentation = None
 
-            for node in [
-                nodegroup[1]
-                for nodegroup in node.value
-                if isinstance(nodegroup[1], ruamelyaml.nodes.MappingNode)
-            ]:
-                if previous_indentation is None:
-                    previous_indentation = node.start_mark.column
-                if node.start_mark.column != previous_indentation:
-                    raise exceptions.InconsistentIndentationDisallowed(
-                        "While parsing",
-                        node.start_mark,
-                        "Found mapping with indentation "
-                        "inconsistent with previous mapping",
-                        node.end_mark,
-                    )
+        for node in [
+            nodegroup[1]
+            for nodegroup in node.value
+            if isinstance(nodegroup[1], ruamelyaml.nodes.MappingNode)
+        ]:
+            if previous_indentation is None:
+                previous_indentation = node.start_mark.column
+            if node.start_mark.column != previous_indentation:
+                raise exceptions.InconsistentIndentationDisallowed(
+                    "While parsing",
+                    node.start_mark,
+                    "Found mapping with indentation "
+                    "inconsistent with previous mapping",
+                    node.end_mark,
+                )
 
 
 StrictYAMLConstructor.add_constructor(


### PR DESCRIPTION
This reverts commit d3386a2afc773e71f66f0702e06e1dcf5a8454e4.