### PR TITLE
BUGFIX : Fully parse URL, fix #141

### DIFF
--- a/hitch/story/email-url.story
+++ b/hitch/story/email-url.story
@@ -15,10 +15,10 @@ Email and URL validators:
       given:
         yaml_snippet: |
           a: billg@microsoft.com
-          b: http://www.twitter.com/@realDonaldTrump
+          b: https://user:pass@example.com:443/path?k=v#frag
       steps:
       - Run: |
-          Ensure(load(yaml_snippet, schema)).equals({"a": "billg@microsoft.com", "b": "http://www.twitter.com/@realDonaldTrump"})
+          Ensure(load(yaml_snippet, schema)).equals({"a": "billg@microsoft.com", "b": "https://user:pass@example.com:443/path?k=v#frag"})
 
     Exception:
       given:

--- a/strictyaml/constants.py
+++ b/strictyaml/constants.py
@@ -6,6 +6,4 @@ BOOL_VALUES = TRUE_VALUES + FALSE_VALUES
 
 REGEXES = {
     "email": r".+?\@.+?",
-    # https://urlregex.com/
-    "url": r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+",
 }


### PR DESCRIPTION
use `urllib.parse.urlparse` instead of regex, as suggested in #141.

as an URL can be any string without slashes, here we check that is absolute (as was the case with the regex).