### PR TITLE
added octal numbers

### DIFF
--- a/strictyaml/scalar.py
+++ b/strictyaml/scalar.py
@@ -209,6 +209,23 @@ class HexInt(ScalarValidator):
         raise YAMLSerializationError("'{}' not a hexademial integer.".format(data))
 
 
+class OctInt(ScalarValidator):
+    def validate_scalar(self, chunk):
+        val = chunk.contents
+        if not utils.is_octal(val):
+            chunk.expecting_but_found("when expecting an octal integer")
+        return int(val, 8)
+
+    def to_yaml(self, data):
+        if utils.is_octal(data):
+            if isinstance(data, int):
+                return oct(data)
+            else:
+                return data
+        raise YAMLSerializationError("'{}' not an octal integer.".format(data))
+
+
+
 class Bool(ScalarValidator):
     def validate_scalar(self, chunk):
         val = chunk.contents

--- a/strictyaml/utils.py
+++ b/strictyaml/utils.py
@@ -79,6 +79,31 @@ def is_integer(value):
     return compile(r"^[-+]?[0-9_]+$").match(value) is not None
 
 
+def is_octal(value):
+    """
+    Is a string a string of a octal integer?
+
+    >>> is_octal("0o15")
+    True
+
+    >>> is_octal("0O15")
+    True
+
+    >>> is_octal("0o19")
+    False
+
+    >>> is_octal("o15")
+    False
+
+    >>> is_octal("16")
+    False
+
+    >>> is_octal("1")
+    False
+    """
+    return compile(r"^0[oO][0-7]+$").match(value) is not None
+
+
 def is_hexadecimal(value):
     """
     Is a string a string of a hexademcial integer?


### PR DESCRIPTION
I think that octal numbers can be used for different applications and are relevant for some applications. For example, our system needs octal numbers as input, which should determine Linux file permissions. I think that other developers can also benefit from this feature.